### PR TITLE
Hotfix/keep search path

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -15,7 +15,7 @@ exports.register = function(plugin, options, next){
 
     if (version && !pattern.test(urlPath[0])){
       urlPath.unshift('', version[1]);
-      request.setUrl(urlPath.join('/'));
+      request.setUrl(urlPath.join('/') + (request.url.search || ''));
     }
 
     reply.continue();


### PR DESCRIPTION
Keep search path

using such options :

``` js
Server.register({
  register: require('hapi-versioning'),
  options: {
    pattern: /application\/vnd\.foo\+json; version=(v\d+)/,
    header: 'accept'
  }}, () => {})
```

match whole pattern : it tooks for `/application/vnd.foo+json; version=v1/bar` instead of  `/v1/bar`

Using the plugin search path is deleted, ie `/foo?bar` become `/foo`. This is also fixed
